### PR TITLE
Add Jest testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ See [app/api/user-daycare-providers/route.ts](app/api/user-daycare-providers/rou
 
 ## Testing
 
-Unit tests for email parsers and other core logic can be found in relevant `*.test.ts` files.
+Unit tests are written with **Jest** and can be found in `*.test.ts` files.
 
 Run tests with:
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build:test": "cp .env.test .env && next build",
     "build:prod": "cp .env.prod .env && next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -80,5 +81,10 @@
     "typescript": "^5.8.3",
     "vaul": "^0.9.9",
     "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- install jest/ts-jest/@types/jest dev dependencies
- configure Jest via `jest.config.ts`
- add test script in `package.json`
- document Jest usage in README

## Testing
- `yarn install` *(fails: tunneling socket could not be established)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68425eb5b8c083298190f3587d42c9bb