### PR TITLE
Add link to add child when log list empty

### DIFF
--- a/app/log/page.tsx
+++ b/app/log/page.tsx
@@ -9,6 +9,7 @@ import MealForm from './_components/meal-form';
 import SleepForm from './_components/sleep-form';
 import BathroomForm from './_components/bathroom-form';
 import ActivityForm from './_components/activity-form';
+import Link from 'next/link';
 import supabaseClient from '@/lib/supabase/client'; // Use default import, renamed for clarity
 import { type Database, type Tables } from '@/lib/supabase/types'; // Import Tables utility type
 
@@ -57,7 +58,13 @@ export default function ManualLogPage() {
       {isLoadingChildren ? (
         <p>Loading children...</p>
       ) : children.length === 0 ? (
-        <p>No children found. Please add a child first.</p> // TODO: Link to add child page
+        <p>
+          No children found. Please{' '}
+          <Link href="/children/add" className="text-blue-500 underline">
+            add a child
+          </Link>{' '}
+          first.
+        </p>
       ) : (
         <Card>
           <CardHeader>


### PR DESCRIPTION
## Summary
- import `Link` in `app/log/page.tsx`
- show link to `/children/add` when no children are found

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68425ebc9b7083299ce1826e543f97c3